### PR TITLE
Feature/multi trial kfold cv

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,6 @@ We've provided a utility function `inverse_covariance.plot_util.trace_plot` that
 
 * ["The graphical lasso: New Insights and alternatives"](https://web.stanford.edu/~hastie/Papers/glassoinsights.pdf) Mazumder and Hastie, 2012.
 
+### Repeated KFold cross-validation
+
+* ["Cross-validation pitfalls when selecting and assessing regression and classification models"](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3994246/) D. Krstajic, L. Buturovic, D. Leahy, and S. Thomas, 2014.

--- a/inverse_covariance/__init__.py
+++ b/inverse_covariance/__init__.py
@@ -15,6 +15,7 @@ from .metrics import (
 )
 from .model_average import ModelAverage
 from .adaptive_graph_lasso import AdaptiveGraphLasso
+from .cross_validation import RepeatedKFold
 
 __all__ = [
     'InverseCovarianceEstimator',
@@ -28,4 +29,5 @@ __all__ = [
     'ebic',
     'ModelAverage',
     'AdaptiveGraphLasso',
+    'RepeatedKFold',
 ]

--- a/inverse_covariance/cross_validation.py
+++ b/inverse_covariance/cross_validation.py
@@ -1,0 +1,103 @@
+from abc import ABCMeta, abstractmethod
+from sklearn.cross_validation import _PartitionIterator
+
+
+class _BaseRepeatedKFold(with_metaclass(ABCMeta, _PartitionIterator)):
+    """Base class to validate KFoldRepeated approaches"""
+
+    @abstractmethod
+    def __init__(self, n, n_folds, n_trials, random_state):
+        super(_BaseRepeatedKFold, self).__init__(n)
+
+        if abs(n_folds - int(n_folds)) >= np.finfo('f').eps:
+            raise ValueError("n_folds must be an integer")
+        self.n_folds = n_folds = int(n_folds)
+
+        if n_folds <= 1:
+            raise ValueError(
+                "repeated k-fold cross validation requires at least one"
+                " train / test split by setting n_folds=2 or more,"
+                " got n_folds={0}.".format(n_folds))
+        if n_folds > self.n:
+            raise ValueError(
+                ("Cannot have number of folds n_folds={0} greater"
+                 " than the number of samples: {1}.").format(n_folds, n))
+
+        if not isinstance(n_trials, int) and n_trials > 0:
+            raise TypeError("n_trials must be int and greater than 0;"
+                            " got {0}".format(n_trials))
+        self.n_trials = n_trials
+        self.random_state = random_state
+
+
+class RepeatedKFold(_BaseRepeatedKFold):
+    """Repeated K-Folds cross validation iterator.
+    
+    Provides train/test indices to split data in train test sets. We reshuffle 
+    the data n_trials times and split dataset into k consecutive folds for each
+    trial.
+    
+    Each fold is then used as a validation set once while the k - 1 remaining
+    fold(s) form the training set.
+
+    The iterator will generate n_folds * n_trials train/test splits.
+
+    Technique outlined in:
+        "Cross-validation pitfalls when selecting and assessing 
+        regression and classification models" 
+        D. Krstajic, L. Buturovic, D. Leahy, and S. Thomas
+        https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3994246/
+
+    Parameters
+    ----------
+    n : int
+        Total number of elements.
+    
+    n_folds : int, default=3
+        Number of folds. Must be at least 2.
+    
+    n_trials : int, default=3
+        Number of random index shuffles.
+        n_trials=1 is equivalent to KFold with shuffle=True.
+    
+    random_state : None, int or RandomState
+        If None, use default numpy RNG for shuffling.
+
+    See also
+    --------
+    sklearn.cross_validation.KFold
+    sklearn.cross_validation.ShuffleSplit
+    """
+    def __init__(self, n, n_folds=3, n_trials=3, random_state=None):
+        super(KFold, self).__init__(n, n_folds, n_trials, random_state)
+        rng = check_random_state(self.random_state)
+
+        self.idxs = []
+        for tt in range(self.n_trials):
+            self.idxs.append(rng.shuffle(np.arange(n)))
+
+    def _iter_test_indices(self):
+        n = self.n
+        n_folds = self.n_folds
+        fold_sizes = (n // n_folds) * np.ones(n_folds, dtype=np.int)
+        fold_sizes[:n % n_folds] += 1
+
+        for idxs in self.idxs:
+            current = 0
+            for fold_size in fold_sizes:
+                start, stop = current, current + fold_size
+                yield idxs[start:stop]
+                current = stop
+
+    def __repr__(self):
+        return '%s.%s(n=%i, n_folds=%i, n_trials=%s, random_state=%s)' % (
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.n,
+            self.n_folds,
+            self.n_trials,
+            self.random_state,
+        )
+
+    def __len__(self):
+        return self.n_folds * self.n_trials

--- a/inverse_covariance/cross_validation.py
+++ b/inverse_covariance/cross_validation.py
@@ -89,7 +89,6 @@ class RepeatedKFold(_BaseRepeatedKFold):
         fold_sizes[:n % n_folds] += 1
 
         for idxs in self.idxs:
-            print idxs
             current = 0
             for fold_size in fold_sizes:
                 start, stop = current, current + fold_size

--- a/inverse_covariance/tests/cross_validation_test.py
+++ b/inverse_covariance/tests/cross_validation_test.py
@@ -1,0 +1,39 @@
+from sklearn.utils.testing import assert_raises
+from sklearn.tests.test_cross_validation import check_cv_coverage
+from inverse_covariance import RepeatedKFold
+
+
+def test_repeated_kfold_coverage():
+    n_samples = 300
+    n_folds = 3
+    n_trials = 3
+    kf = RepeatedKFold(n_samples, n_folds, n_trials)
+    check_cv_coverage(kf, expected_n_iter=n_folds * n_trials,
+                      n_samples=n_samples)
+
+    n_samples = 17
+    n_folds = 3
+    n_trials = 5
+    kf = RepeatedKFold(n_samples, n_folds, n_trials)
+    check_cv_coverage(kf, expected_n_iter=n_folds * n_trials,
+                      n_samples=n_samples)
+
+
+def test_repeated_kfold_values():
+    # Check that errors are raised if there is not enough samples
+    assert_raises(ValueError, RepeatedKFold, 3, 4)
+
+    # Error when number of folds is <= 1
+    assert_raises(ValueError, RepeatedKFold, 2, 0)
+    assert_raises(ValueError, RepeatedKFold, 2, 1)
+    error_string = ("repeated k-fold cross validation requires at least one"
+                    " train / test split")
+
+    # When n is not integer:
+    assert_raises(ValueError, RepeatedKFold, 2.5, 2)
+
+    # When n_folds is not integer:
+    assert_raises(ValueError, RepeatedKFold, 5, 1.5)
+
+    # When n_trials is not integer:
+    assert_raises(ValueError, RepeatedKFold, 5, 3, 1.5)


### PR DESCRIPTION
Defines a `RepeatedKFold` cross validation generator and wires in as the default cross-validation scheme.  Adds support for passing cv=(n_folds, n_trials) to `QuicGraphLassoCV` if so desired.

Addresses #59 .   Review @mnarayan ?