### PR TITLE
Feature/spark monte carlo

### DIFF
--- a/examples/profiling_example.py
+++ b/examples/profiling_example.py
@@ -34,7 +34,7 @@ metrics = {
 
 mc = MonteCarloProfile(n_features=50, n_trials=10, graph=LatticeGraph(),
                        n_samples_grid=10, alpha_grid=5, metrics=metrics, 
-                       verbose=True)
+                       verbose=True, n_jobs=2)
 mc.fit()
 
 ###############################################################################

--- a/examples/profiling_example.py
+++ b/examples/profiling_example.py
@@ -34,7 +34,7 @@ metrics = {
 
 mc = MonteCarloProfile(n_features=50, n_trials=10, graph=LatticeGraph(),
                        n_samples_grid=10, alpha_grid=5, metrics=metrics, 
-                       verbose=True, n_jobs=2)
+                       verbose=True, n_jobs=4)
 mc.fit()
 
 ###############################################################################

--- a/inverse_covariance/profiling/monte_carlo_profile.py
+++ b/inverse_covariance/profiling/monte_carlo_profile.py
@@ -257,20 +257,29 @@ class MonteCarloProfile(object):
             zip(range(len(trial_param_grid)), trial_param_grid)
         )
 
-        mc_fit = partial(_mc_fit, 
-                         estimator=self.mc_estimator,
-                         metrics=self.metrics,
-                         prng=self.prng)
+        mc_fit = partial(
+            _mc_fit, 
+            estimator=self.mc_estimator,
+            metrics=self.metrics
+        )
         
         if self.verbose:
             print 'Fitting MC trials...'
 
         if self.sc is not None:
-            mc_results = _spark_map(mc_fit, indexed_trial_param_grid, self.sc,
-                                    self.seed + len(param_grid))
+            mc_results = _spark_map(
+                mc_fit,
+                indexed_trial_param_grid,
+                self.sc,
+                self.seed + len(param_grid)
+            )
         else:
-            mc_results = _cpu_map(mc_fit, indexed_trial_param_grid, self.n_jobs,
-                                  self.verbose)
+            mc_results = _cpu_map(
+                partial(mc_fit, prng=self.prng),
+                indexed_trial_param_grid,
+                self.n_jobs,
+                self.verbose
+            )
 
         # ensure results are ordered correctly
         mc_results = sorted(mc_results, key=lambda r: r[0])

--- a/inverse_covariance/profiling/monte_carlo_profile.py
+++ b/inverse_covariance/profiling/monte_carlo_profile.py
@@ -284,3 +284,4 @@ class MonteCarloProfile(object):
 
         self.is_fitted = True
         return self
+        

--- a/inverse_covariance/profiling/monte_carlo_profile.py
+++ b/inverse_covariance/profiling/monte_carlo_profile.py
@@ -284,4 +284,3 @@ class MonteCarloProfile(object):
 
         self.is_fitted = True
         return self
-        

--- a/inverse_covariance/profiling/tests/monte_carlo_profile_test.py
+++ b/inverse_covariance/profiling/tests/monte_carlo_profile_test.py
@@ -60,7 +60,7 @@ class TestMonteCarloProfile(object):
             assert np.sum(mc.results_[key].flat) > 0
             assert mc.results_[key].shape == (len(mc.alphas_), len(mc.grid_))
 
-        assert len(mc.precision_nnz_) == len(mc.alphas_)
+        assert len(mc.precision_nnz_) == len(mc.alphas_) * len(mc.grid_)
         assert mc.precision_nnz_[0] == params_in['n_features'] # for eye
 
         if isinstance(mc.n_samples_grid, int):
@@ -92,7 +92,7 @@ class TestMonteCarloProfile(object):
             assert np.sum(mc.results_[key].flat) > 0
             assert mc.results_[key].shape == (len(mc.alphas_), len(mc.grid_))
 
-        assert len(mc.precision_nnz_) == len(mc.alphas_)
+        assert len(mc.precision_nnz_) == len(mc.alphas_) * len(mc.grid_)
 
         if isinstance(mc.n_samples_grid, int):
             assert len(mc.grid_) == mc.n_samples_grid

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ with open('requirements.txt') as f:
 
 
 setup(name='skggm',
-    version='0.2.0',
+    version='0.2.1',
     description='Gaussian graphical models for scikit-learn.',
     author='Jason Laska and Manjari Narayan',
     license='MIT',


### PR DESCRIPTION
Refactors `MonteCarloProfile` so that it can be used with both sklearn's `Parallel` and an Apache Spark/pyspark `sparkContext`.  Spark version has been tested on Databricks' platform.

In particular:

- picks graphs and learn all lambdas (model selection step) as an independent step first
- map over all graphs, lambdas, and trials as a giant iteration step;  this latter part follows much more of a map-reduce style vs. previously.

Each parallel spark worker (think: cpu core per cluster machine) needs to use a separately seeded instance of np.random.RandomState or the results will be the same on each worker.  This is ok right?  The seeds are automatically derived from an initial user-seeded value in the class.  

The non-spark version remains unchanged (only refactored).

r @mnarayan ?