### PR TITLE
Feature/spark cv

### DIFF
--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -553,7 +553,7 @@ class QuicGraphLassoCV(InverseCovarianceEstimator):
         results = list()
         t0 = time.time()
         for rr in range(n_refinements):
-            if sc is None:
+            if self.sc is None:
                 # parallel version
                 this_result = Parallel(
                     n_jobs=self.n_jobs,


### PR DESCRIPTION
Enable using spark for cross validation iterations in QuicGraphLassoCV.

Unfortunately I do not think it is possible to use this simultaneously in conjunction with MonteCarloProfile (spark) or ModelAverage (spark, upcoming).

r @mnarayan ?