### PR TITLE
Better frobenius that doesnt cound diagonal.

### DIFF
--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -49,8 +49,7 @@ def _compute_error(comp_cov, covariance_, precision_, score_metric='frobenius'):
         If False, the error norm is returned.
     """
     if score_metric == "frobenius":
-        error = comp_cov - covariance_
-        return np.sum(error ** 2)                        
+        return np.linalg.norm(np.triu(comp_cov - covariance_, 1), ord='fro')                       
     elif score_metric == "spectral":
         error = comp_cov - covariance_
         return np.amax(np.linalg.svdvals(np.dot(error.T, error)))


### PR DESCRIPTION
Replaces Forbenius computation in `InverseCovarianceEstimator` to use numpy and avoid diagonal.  All instances of this metric work like this now.