### PR TITLE
#bugfix addressing issue #86. Also changes default number of trials t…

### DIFF
--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -534,10 +534,12 @@ class QuicGraphLassoCV(InverseCovarianceEstimator):
         X = as_float_array(X, copy=False, force_all_finite=False)
         
         if self.cv is None:
-            cv = (3, 3)
+            cv = (3, 10)
         elif isinstance(self.cv, int):
-            cv = (self.cv, 3) # upgrade with default number of trials
-        
+            cv = (self.cv, 10) # upgrade with default number of trials
+	elif isinstance(self.cv, tuple):
+	    cv = self.cv        
+
         if isinstance(cv, tuple):
             if not sp.issparse(X):
                 n_samples = len(X)


### PR DESCRIPTION
Aside from addressing #86 to check `cv`,  I realized that using only 3 trials with default `cv=(3,3)` option was perhaps too few. The default argument is now `cv=(3,10)` 
