### PR TITLE
Feature/add rank correlation

### DIFF
--- a/inverse_covariance/__init__.py
+++ b/inverse_covariance/__init__.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 from .inverse_covariance import (
     InverseCovarianceEstimator,
 )
-from .rank_correlation import(
-    compute_ranks,
-    spearman_correlation
-)
 from .quic_graph_lasso import (
     quic,
     QuicGraphLasso,

--- a/inverse_covariance/__init__.py
+++ b/inverse_covariance/__init__.py
@@ -16,6 +16,7 @@ from .metrics import (
 )
 from .rank_correlation import (
     spearman_correlation,
+    kendalltau_correlation,
 )
 from .model_average import ModelAverage
 from .adaptive_graph_lasso import AdaptiveGraphLasso
@@ -32,6 +33,7 @@ __all__ = [
     'quadratic_loss',
     'ebic',
     'spearman_correlation',
+    'kendalltau_correlation',
     'ModelAverage',
     'AdaptiveGraphLasso',
     'RepeatedKFold',

--- a/inverse_covariance/__init__.py
+++ b/inverse_covariance/__init__.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 from .inverse_covariance import (
     InverseCovarianceEstimator,
 )
+from .rank_correlation import(
+    compute_ranks,
+    spearman_correlation
+)
 from .quic_graph_lasso import (
     quic,
     QuicGraphLasso,

--- a/inverse_covariance/__init__.py
+++ b/inverse_covariance/__init__.py
@@ -14,6 +14,9 @@ from .metrics import (
     quadratic_loss,
     ebic,
 )
+from .rank_correlation import (
+    spearman_correlation,
+)
 from .model_average import ModelAverage
 from .adaptive_graph_lasso import AdaptiveGraphLasso
 from .cross_validation import RepeatedKFold
@@ -28,6 +31,7 @@ __all__ = [
     'kl_loss',
     'quadratic_loss',
     'ebic',
+    'spearman_correlation',
     'ModelAverage',
     'AdaptiveGraphLasso',
     'RepeatedKFold',

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -103,8 +103,12 @@ class InverseCovarianceEstimator(BaseEstimator):
                   'kl', or 'quadratic'
         Used for computing self.score().
 
-    init_method : one of 'corrcoef', 'cov', or custom function
+    init_method : one of 'corrcoef', 'cov', 'spearman', 'kendalltau',
+        or a custom function.
         Computes initial covariance and scales lambda appropriately.
+        Using the custom function extends graphical model estimation to
+        distributions beyond the multivariate Gaussian. 
+        The `spearman` or `kendalltau` options extend inverse covariance                estimation to nonparanormal and transelliptic graphical models.
         Custom function must return ((n_features, n_features) ndarray, float)
         where the scalar parameter will be used to scale the penalty lam.
 

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -341,8 +341,5 @@ class InverseCovarianceEstimator(BaseEstimator):
             return
 
         ebic_scores = self.ebic(gamma=gamma)
-        print(ebic_scores)
-        print(ebic_scores.min())
-        print(np.abs(ebic_scores - ebic_scores.min()))
         min_indices = np.where(np.abs(ebic_scores - ebic_scores.min()) < 1e-10)
         return np.max(min_indices)

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -9,16 +9,17 @@ from .rank_correlation import (
     kendalltau_correlation,
 )
 
+
 def _init_coefs(X, method='corrcoef'):
     if method == 'corrcoef':
         return np.corrcoef(X, rowvar=False), 1.0
     elif method == 'cov':
         init_cov = np.cov(X, rowvar=False)
         return init_cov, np.max(np.abs(np.triu(init_cov)))
-    elif method == 'spearman':        
+    elif method == 'spearman':
         return spearman_correlation(X, rowvar=False), 1.0
     elif method == 'kendalltau':
-        return kendalltau_correlation(X, rowvar=False), 1.0   
+        return kendalltau_correlation(X, rowvar=False), 1.0
     elif callable(method):
         return method(X)
     else:

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -341,5 +341,8 @@ class InverseCovarianceEstimator(BaseEstimator):
             return
 
         ebic_scores = self.ebic(gamma=gamma)
+        print(ebic_scores)
+        print(ebic_scores.min())
+        print(np.abs(ebic_scores - ebic_scores.min()))
         min_indices = np.where(np.abs(ebic_scores - ebic_scores.min()) < 1e-10)
         return np.max(min_indices)

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -107,8 +107,9 @@ class InverseCovarianceEstimator(BaseEstimator):
         or a custom function.
         Computes initial covariance and scales lambda appropriately.
         Using the custom function extends graphical model estimation to
-        distributions beyond the multivariate Gaussian. 
-        The `spearman` or `kendalltau` options extend inverse covariance                estimation to nonparanormal and transelliptic graphical models.
+        distributions beyond the multivariate Gaussian.
+        The `spearman` or `kendalltau` options extend inverse covariance
+        estimation to nonparanormal and transelliptic graphical models.
         Custom function must return ((n_features, n_features) ndarray, float)
         where the scalar parameter will be used to scale the penalty lam.
 

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -4,6 +4,7 @@ import numpy as np
 from sklearn.base import BaseEstimator
 
 from . import metrics
+from rank_correlation import spearman_correlation
 
 
 def _init_coefs(X, method='corrcoef'):
@@ -12,6 +13,9 @@ def _init_coefs(X, method='corrcoef'):
     elif method == 'cov':
         init_cov = np.cov(X, rowvar=False)
         return init_cov, np.max(np.abs(np.triu(init_cov)))
+    elif method == 'spearman':
+        init_cov = spearman_correlation(X)
+        return init_cov, 1.0
     elif callable(method):
         return method(X)
     else:

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -4,8 +4,10 @@ import numpy as np
 from sklearn.base import BaseEstimator
 
 from . import metrics
-from .rank_correlation import spearman_correlation
-
+from .rank_correlation import (
+    spearman_correlation,
+    kendalltau_correlation,
+)
 
 def _init_coefs(X, method='corrcoef'):
     if method == 'corrcoef':
@@ -13,9 +15,10 @@ def _init_coefs(X, method='corrcoef'):
     elif method == 'cov':
         init_cov = np.cov(X, rowvar=False)
         return init_cov, np.max(np.abs(np.triu(init_cov)))
-    elif method == 'spearman':
-        init_cov = spearman_correlation(X)
-        return init_cov, 1.0
+    elif method == 'spearman':        
+        return spearman_correlation(X, rowvar=False), 1.0
+    elif method == 'kendalltau':
+        return kendalltau_correlation(X, rowvar=False), 1.0   
     elif callable(method):
         return method(X)
     else:

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.base import BaseEstimator
 
 from . import metrics
-from rank_correlation import spearman_correlation
+from .rank_correlation import spearman_correlation
 
 
 def _init_coefs(X, method='corrcoef'):

--- a/inverse_covariance/metrics.py
+++ b/inverse_covariance/metrics.py
@@ -113,9 +113,15 @@ def ebic(covariance, precision, n_samples, n_features, gamma=0):
     l_theta = -np.sum(covariance * precision) + fast_logdet(precision)
     l_theta *= n_features / 2.
 
+    # is something goes wrong with fast_logdet, return large value
+    if np.isinf(l_theta) or np.isnan(l_theta):
+        return 1e10
+
     mask = np.abs(precision.flat) > np.finfo(precision.dtype).eps
     precision_nnz = (np.sum(mask) - n_features) / 2.0  # lower off diagonal tri
 
-    return -2.0 * l_theta +\
-        precision_nnz * np.log(n_samples) +\
+    return (
+        -2.0 * l_theta +
+        precision_nnz * np.log(n_samples) +
         4.0 * precision_nnz * np.log(n_features) * gamma
+    )

--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -648,6 +648,7 @@ class QuicGraphLassoCV(InverseCovarianceEstimator):
             # in case of equality)
             best_score = -np.inf
             last_finite_idx = 0
+            best_index = 0
             for index, (lam, scores, _) in enumerate(results):
                 # sometimes we get -np.inf in the result (in kl-loss)
                 scores = [s for s in scores if not np.isinf(s)]

--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -201,8 +201,13 @@ class QuicGraphLasso(InverseCovarianceEstimator):
                   'kl', or 'quadratic'
         Used for computing self.score().
 
-    init_method : one of 'corrcoef', 'cov', or custom function
+    init_method : one of 'corrcoef', 'cov', 'spearman', 'kendalltau',
+        or a custom function.
         Computes initial covariance and scales lambda appropriately.
+        Using the custom function extends graphical model estimation to
+        distributions beyond the multivariate Gaussian.
+        The `spearman` or `kendalltau` options extend inverse covariance
+        estimation to nonparanormal and transelliptic graphical models.
         Custom function must return ((n_features, n_features) ndarray, float)
         where the scalar parameter will be used to scale the penalty lam.
 
@@ -465,8 +470,13 @@ class QuicGraphLassoCV(InverseCovarianceEstimator):
                   'kl', or 'quadratic'
         Used for computing self.score().
 
-    init_method : one of 'corrcoef', 'cov', or custom function
+    init_method : one of 'corrcoef', 'cov', 'spearman', 'kendalltau',
+        or a custom function.
         Computes initial covariance and scales lambda appropriately.
+        Using the custom function extends graphical model estimation to
+        distributions beyond the multivariate Gaussian.
+        The `spearman` or `kendalltau` options extend inverse covariance
+        estimation to nonparanormal and transelliptic graphical models.
         Custom function must return ((n_features, n_features) ndarray, float)
         where the scalar parameter will be used to scale the penalty lam.
 
@@ -772,8 +782,13 @@ class QuicGraphLassoEBIC(InverseCovarianceEstimator):
     verbose : integer
         Used in quic routine.
 
-    init_method : one of 'corrcoef', 'cov', or custom function
+    init_method : one of 'corrcoef', 'cov', 'spearman', 'kendalltau',
+        or a custom function.
         Computes initial covariance and scales lambda appropriately.
+        Using the custom function extends graphical model estimation to
+        distributions beyond the multivariate Gaussian.
+        The `spearman` or `kendalltau` options extend inverse covariance
+        estimation to nonparanormal and transelliptic graphical models.
         Custom function must return ((n_features, n_features) ndarray, float)
         where the scalar parameter will be used to scale the penalty lam.
 

--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -13,7 +13,7 @@ from sklearn.utils import check_array, as_float_array
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.externals.joblib import Parallel, delayed
 from sklearn.model_selection import cross_val_score  # NOQA >= 0.18
-#from sklearn.cross_validation import cross_val_score  # NOQA < 0.18
+# from sklearn.cross_validation import cross_val_score  # NOQA < 0.18
 
 from . import pyquic
 from .inverse_covariance import (
@@ -664,8 +664,8 @@ class QuicGraphLassoCV(InverseCovarianceEstimator):
                 lam_1 = results[0][0]
                 lam_0 = results[1][0]
 
-            elif (best_index == last_finite_idx
-                    and not best_index == len(results) - 1):
+            elif (best_index == last_finite_idx and
+                    not best_index == len(results) - 1):
                 # We have non-converged models on the upper bound of the
                 # grid, we need to refine the grid there
                 lam_1 = results[best_index][0]

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -1,5 +1,7 @@
 """Nonparametric rank correlation estimators as alternative to
  linear correlation estimators."""
+from __future__ import absolute_import
+
 import numpy as np
 from scipy.stats import (
     rankdata,

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -95,7 +95,7 @@ def kendalltau_correlation(X, rowvar=False, weighted=False):
      arXiv:1502.07641
     """
 
-    if(rowvar):
+    if rowvar:
         X = X.T
 
     _, n_features = X.shape
@@ -137,4 +137,5 @@ def trimmean_correlation(X, rowvar=False, weighted=False):
     undirected graphs."
     Journal of Machine Learning Research 10.Oct (2009): 2295-2328.
     """
+
     pass

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.stats import rankdata
 
 
-def compute_ranks(X):
+def _compute_ranks(X):
     """
     Transform each column into ranked data. Tied ranks are averaged.
 
@@ -43,7 +43,7 @@ def spearman_correlation(X):
     -------
     rank_correlation
     """
-    Xrank = compute_ranks(X)
+    Xrank = _compute_ranks(X)
     rank_correlation = np.corrcoef(Xrank, rowvar=False)
 
     return 2 * np.sin(rank_correlation * np.pi / 6)

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -27,7 +27,7 @@ def _compute_ranks(X):
     return Xrank
 
 
-def spearman_correlation(X):
+def spearman_correlation(X,rowvar=False):
     """
     Computes the spearman correlation estimate.
     This is effectively a bias corrected pearson correlation

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -1,0 +1,67 @@
+"""Nonparametric rank correlation estimators as alternative to
+ linear correlation estimators."""
+import numpy as np
+from scipy.stats import rankdata
+
+
+def compute_ranks(X):
+    """
+    Transform each column into ranked data. Tied ranks are averaged.
+
+    Parameters
+    ----------
+    X : array-like, shape = (n_samples, n_features)
+        The data matrix where each column is a feature.
+         Row observations for each column will be replaced
+         by correponding rank
+
+    Returns
+    -------
+    Xrank
+    """
+    _, n_features = X.shape
+    Xrank = np.zeros(shape=X.shape)
+    for col in np.arange(n_features):
+        Xrank[:, col] = rankdata(X[:, col], method='average')
+
+    return Xrank
+
+
+def spearman_correlation(X):
+    """
+    Computes the spearman correlation estimate.
+    This is effectively a bias corrected pearson correlation
+    between rank transformed columns of X.
+
+    Parameters
+    ----------
+    X: array-like, shape = [n_samples, n_features]
+        Data matrix using which we compute the empirical
+        correlation
+
+    Returns
+    -------
+    rank_correlation
+    """
+    Xrank = compute_ranks(X)
+    rank_correlation = np.corrcoef(Xrank, rowvar=False)
+
+    return 2 * np.sin(rank_correlation * np.pi / 6)
+
+
+def kendalltau_correlation(X):
+    """
+    Computes kendall's tau correlation estimate.
+
+    Parameters
+    ----------
+    X: array-like, shape = [n_samples, n_features]
+        Data matrix using which we compute the empirical
+        correlation
+
+    Returns
+    -------
+    rank_correlation
+    """
+
+    pass

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -102,12 +102,39 @@ def kendalltau_correlation(X, rowvar=False, weighted=False):
     rank_correlation = np.eye(n_features)
     for row in np.arange(n_features):
         for col in np.arange(1+row, n_features):
-            if(weighted):
+            if weighted:
                 rank_correlation[row, col], _ = weightedtau(
-                    X[:, row], X[:, col], rank=False)
+                    X[:, row], X[:, col], rank=False
+                )
             else:
                 rank_correlation[row, col], _ = kendalltau(
-                    X[:, row], X[:, col])
+                    X[:, row], X[:, col]
+                )
     rank_correlation = np.triu(rank_correlation, 1) + rank_correlation.T
 
     return np.sin(rank_correlation * np.pi / 2)
+
+
+def trimmean_correlation(X, rowvar=False, weighted=False):
+    """
+    Computes a winsorized estimate of pairwise correlations
+
+    Parameters
+    ----------
+    X: array-like, shape = [n_samples, n_features]
+        Data matrix using which we compute the empirical
+        correlation
+
+    Returns
+    -------
+    rank_correlation
+
+    References
+    ----------
+
+    Liu, Han, John Lafferty, and Larry Wasserman.
+    "The nonparanormal: Semiparametric estimation of high dimensional
+    undirected graphs."
+    Journal of Machine Learning Research 10.Oct (2009): 2295-2328.
+    """
+    pass

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -1,7 +1,11 @@
 """Nonparametric rank correlation estimators as alternative to
  linear correlation estimators."""
 import numpy as np
-from scipy.stats import rankdata
+from scipy.stats import (
+    rankdata,
+    kendalltau,
+    weightedtau
+)
 
 
 def _compute_ranks(X):
@@ -27,7 +31,7 @@ def _compute_ranks(X):
     return Xrank
 
 
-def spearman_correlation(X,rowvar=False):
+def spearman_correlation(X, rowvar=False):
     """
     Computes the spearman correlation estimate.
     This is effectively a bias corrected pearson correlation
@@ -42,16 +46,31 @@ def spearman_correlation(X,rowvar=False):
     Returns
     -------
     rank_correlation
+
+    References
+    ----------
+
+    Xue, Lingzhou; Zou, Hui.
+    "Regularized rank-based estimation of high-dimensional
+    nonparanormal graphical models."
+    Ann. Statist. 40 (2012), no. 5, 2541--2571. doi:10.1214/12-AOS1041.
+
+    Liu, Han, Fang; Yuan, Ming; Lafferty, John; Wasserman, Larry.
+    "High-dimensional semiparametric Gaussian copula graphical models."
+    Ann. Statist. 40.4 (2012): 2293-2326. doi:10.1214/12-AOS1037
     """
+
     Xrank = _compute_ranks(X)
-    rank_correlation = np.corrcoef(Xrank, rowvar=False)
+    rank_correlation = np.corrcoef(Xrank, rowvar=rowvar)
 
     return 2 * np.sin(rank_correlation * np.pi / 6)
 
 
-def kendalltau_correlation(X):
+def kendalltau_correlation(X, rowvar=False, weighted=False):
     """
     Computes kendall's tau correlation estimate.
+    The option to use scipy.stats.weightedtau is not recommended
+    as the implementation does not appear to handle ties correctly.
 
     Parameters
     ----------
@@ -62,6 +81,33 @@ def kendalltau_correlation(X):
     Returns
     -------
     rank_correlation
+
+    References
+    ----------
+
+    Liu, Han, Fang; Yuan, Ming; Lafferty, John; Wasserman, Larry.
+    "High-dimensional semiparametric Gaussian copula graphical models."
+    Ann. Statist. 40.4 (2012): 2293-2326. doi:10.1214/12-AOS1037
+
+    Barber, Rina Foygel; Kolar, Mladen.
+    "ROCKET: Robust Confidence Intervals via Kendall's Tau
+    for Transelliptical Graphical Models."
+     arXiv:1502.07641
     """
 
-    pass
+    if(rowvar):
+        X = X.T
+
+    _, n_features = X.shape
+    rank_correlation = np.eye(n_features)
+    for row in np.arange(n_features):
+        for col in np.arange(1+row, n_features):
+            if(weighted):
+                rank_correlation[row, col], _ = weightedtau(
+                    X[:, row], X[:, col], rank=False)
+            else:
+                rank_correlation[row, col], _ = kendalltau(
+                    X[:, row], X[:, col])
+    rank_correlation = np.triu(rank_correlation, 1) + rank_correlation.T
+
+    return np.sin(rank_correlation * np.pi / 2)

--- a/inverse_covariance/rank_correlation.py
+++ b/inverse_covariance/rank_correlation.py
@@ -46,11 +46,15 @@ def _compute_ranks(X, winsorize=False, truncation=None, verbose=True):
 
     if winsorize:
         if truncation is None:
-            truncation = 1 / (4 * np.power(n_samples, 0.25) *
-                np.sqrt(np.pi * np.log(n_samples)))
+            truncation = (
+                1 / (
+                    4 * np.power(n_samples, 0.25) *
+                    np.sqrt(np.pi * np.log(n_samples))
+                )
+            )
+
         elif (truncation > 1):
             truncation = np.min(1.0, truncation)
-        print "Winsorizing on. Truncation: {} ".format(truncation)
 
     for col in np.arange(n_features):
         Xrank[:, col] = rankdata(X[:, col], method='average')

--- a/inverse_covariance/tests/quic_graph_lasso_test.py
+++ b/inverse_covariance/tests/quic_graph_lasso_test.py
@@ -44,6 +44,16 @@ class TestQuicGraphLasso(object):
             'max_iter': 100,
             'init_method': custom_init,
         }, [0.0071706976421055616, 1394.564448134179, 50.890448754467911, 7.1054273576010019e-15]),  # NOQA
+        ({
+            'lam': 1.0,
+            'max_iter': 100,
+            'init_method': 'spearman',
+        }, [3.1622776601683795, 3.1622776601683795, 10.0, 1.7763568394002505e-15]),  # NOQA
+        ({
+            'lam': 1.0,
+            'max_iter': 100,
+            'init_method': 'kendalltau',
+        }, [3.1622776601683795, 3.1622776601683795, 10.0, 0.0]),  # NOQA
     ])
     def test_integration_quic_graph_lasso(self, params_in, expected):
         '''
@@ -82,6 +92,16 @@ class TestQuicGraphLasso(object):
             'max_iter': 100,
             'init_method': 'cov',
         }, [0.0071706976421055616, 1394.564448134179, 50.890448754467911, 7.1054273576010019e-15]),  # NOQA
+        ({
+            'lam': 1.0,
+            'max_iter': 100,
+            'init_method': 'spearman',
+        }, [3.1622776601683795, 3.1622776601683795, 10.0, 0.0]),  # NOQA
+        ({
+            'lam': 1.0,
+            'max_iter': 100,
+            'init_method': 'kendalltau',
+        }, [3.1622776601683795, 3.1622776601683795, 10.0, 0.0]),  # NOQA
     ])
     def test_integration_quic_graph_lasso_fun(self, params_in, expected):
         '''
@@ -122,6 +142,12 @@ class TestQuicGraphLasso(object):
         ({'lam': 0.5 * np.ones((10, 10)) - 0.5 * np.diag(np.ones((10,))),
           'n_refinements': 1,
           'init_method': custom_init}, [0.0106, 21634.95296, 57.6289, 0.00039]),  # NOQA
+        ({'lam': 0.5 * np.ones((10, 10)) - 0.5 * np.diag(np.ones((10,))),
+          'n_refinements': 1,
+          'init_method': 'spearman'}, [4.8315707207048622, 38.709631332689789, 2.8265068394116657, 1.5312382906085276e-07]),  # NOQA
+        ({'lam': 0.5 * np.ones((10, 10)) - 0.5 * np.diag(np.ones((10,))),
+          'n_refinements': 1,
+          'init_method': 'kendalltau'}, [4.9007318106601074, 85.081499460930743, 2.0463861650623159, 0.00012530384889419821]),  # NOQA
     ])
     def test_integration_quic_graph_lasso_cv(self, params_in, expected):
         '''

--- a/inverse_covariance/tests/rank_correlation_test.py
+++ b/inverse_covariance/tests/rank_correlation_test.py
@@ -2,8 +2,8 @@ import numpy as np
 
 from sklearn.utils.testing import assert_array_almost_equal
 
-from inverse_covariance import (
-    compute_ranks,
+from inverse_covariance.rank_correlation import (
+    _compute_ranks,
     spearman_correlation,
 )
 
@@ -14,7 +14,7 @@ X = np.append(X, X, axis=1)
 
 def test_compute_ranks():
     Y1 = 5.5 * Y
-    Y2 = compute_ranks(Y)
+    Y2 = _compute_ranks(Y)
     assert_array_almost_equal(Y1, Y2)
 
 

--- a/inverse_covariance/tests/rank_correlation_test.py
+++ b/inverse_covariance/tests/rank_correlation_test.py
@@ -27,9 +27,9 @@ def test_spearman_correlation():
 
 def test_kendalltau_correlation():
     A = np.ones(shape=[2, 2])
-    
-    A2 = kendalltau_correlation(X,weighted=False)
+
+    A2 = kendalltau_correlation(X, weighted=False)
     assert_array_almost_equal(A, A2, decimal=3)
-    
-    A3 = kendalltau_correlation(X,weighted=True)
+
+    A3 = kendalltau_correlation(X, weighted=True)
     assert_array_almost_equal(A, A3, decimal=3)

--- a/inverse_covariance/tests/rank_correlation_test.py
+++ b/inverse_covariance/tests/rank_correlation_test.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from sklearn.utils.testing import assert_array_almost_equal
+
+from inverse_covariance import (
+    compute_ranks,
+    spearman_correlation,
+)
+
+Y = np.ones(shape=[10, 2])
+X = .001 * np.random.randn(20, 1)
+X = np.append(X, X, axis=1)
+
+
+def test_compute_ranks():
+    Y1 = 5.5 * Y
+    Y2 = compute_ranks(Y)
+    assert_array_almost_equal(Y1, Y2)
+
+
+def test_spearman_correlation():
+    A = np.ones(shape=[2, 2])
+    A2 = spearman_correlation(X)
+    assert_array_almost_equal(A, A2, decimal=3)

--- a/inverse_covariance/tests/rank_correlation_test.py
+++ b/inverse_covariance/tests/rank_correlation_test.py
@@ -5,6 +5,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from inverse_covariance.rank_correlation import (
     _compute_ranks,
     spearman_correlation,
+    kendalltau_correlation,
 )
 
 Y = np.ones(shape=[10, 2])
@@ -22,3 +23,13 @@ def test_spearman_correlation():
     A = np.ones(shape=[2, 2])
     A2 = spearman_correlation(X)
     assert_array_almost_equal(A, A2, decimal=3)
+
+
+def test_kendalltau_correlation():
+    A = np.ones(shape=[2, 2])
+    
+    A2 = kendalltau_correlation(X,weighted=False)
+    assert_array_almost_equal(A, A2, decimal=3)
+    
+    A3 = kendalltau_correlation(X,weighted=True)
+    assert_array_almost_equal(A, A3, decimal=3)

--- a/inverse_covariance/tests/rank_correlation_test.py
+++ b/inverse_covariance/tests/rank_correlation_test.py
@@ -14,7 +14,7 @@ X = np.append(X, X, axis=1)
 
 
 def test_compute_ranks():
-    Y1 = 5.5 * Y
+    Y1 = 5.5 * Y / Y.shape[0]
     Y2 = _compute_ranks(Y)
     assert_array_almost_equal(Y1, Y2)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Cython>=0.24
 nilearn>=0.2.4
 numpy>=1.12.1
 scikit-learn==0.18.1
-scipy>=0.18.0
+scipy>=0.19.1
 pytest>=2.9.2
 seaborn>=0.7.1
 nose>=1.3.6


### PR DESCRIPTION
Adding in alternative functions to `np.corrcoef` and `np.cov` to initialize sample covariance or correlation for the inverse_covariance class. Offers features requested in #77 

DONE
- [x] Add spearman rank correlation
- [x] Add kendall's tau concordance correlation
- [x] Fix import/namespace issues

TODOs
- [ ] Check that methods can be passed to `init_method` option
- [ ] Winsorized correlation 