### PR TITLE
[MRG] put black dependency as optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 
 # command to run tests
 script:
+    - pip install black
     - black --check inverse_covariance
     - black --check examples
     - python -m pytest --showlocals --pyargs

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,11 @@ addons:
 install:
     - pip install -U pip wheel
     - pip install --install-option="--no-cython-compile" cython
-    - pip install -r requirements.txt
+    - pip install -r dev-requirements.txt
     - python setup.py develop
 
 # command to run tests
 script:
-    - pip install black
     - black --check inverse_covariance
     - black --check examples
     - python -m pytest --showlocals --pyargs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+black==18.6b4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pytest>=2.9.2
 seaborn>=0.7.1
 nose>=1.3.6
 tabulate==0.7.5
-black==18.6b4

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'inverse_covariance.profiling',
         'inverse_covariance.pyquic'],
     install_requires=INSTALL_REQUIRES,
-    extras_require=dict(contribute=['black==18.6b4']),
     url='https://github.com/skggm/skggm',
     author_email='jlaska@gmail.com',
     ext_package='inverse_covariance',

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'inverse_covariance.profiling',
         'inverse_covariance.pyquic'],
     install_requires=INSTALL_REQUIRES,
+    extras_require=dict(contribute=['black==18.6b4']),
     url='https://github.com/skggm/skggm',
     author_email='jlaska@gmail.com',
     ext_package='inverse_covariance',


### PR DESCRIPTION
Fixes #119 

I couldn't install `skggm` with python2.7 because black does not seem to exist in python 2.7 (see https://github.com/ambv/black#installation). I thought this could be a fix (putting `black` as an optional dependency), but I may be totally wrong here