### PR TITLE
change sklearn.utils.testing to numpy.testing

### DIFF
--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -8,7 +8,7 @@ from functools import partial
 
 from sklearn.covariance import EmpiricalCovariance
 from sklearn.utils import check_array, as_float_array, deprecated
-from sklearn.utils.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 from joblib import Parallel, delayed
 from sklearn.model_selection import cross_val_score, RepeatedKFold
 


### PR DESCRIPTION
"from sklearn.utils.testing import assert_array_almost_equal" would throw an error due to its removal in sklearn>=0.24. Thus, the same function from numpy.testing is imported.