### PR TITLE
Bump scikit-learn compatibility

### DIFF
--- a/examples/estimator_suite.py
+++ b/examples/estimator_suite.py
@@ -13,9 +13,9 @@ import numpy as np
 import tabulate
 import time
 
-from sklearn.grid_search import GridSearchCV
+from sklearn.model_selection import GridSearchCV
 from sklearn.datasets import make_sparse_spd_matrix
-from sklearn.covariance import GraphLassoCV, ledoit_wolf
+from sklearn.covariance import GraphicalLassoCV, ledoit_wolf
 import matplotlib.pyplot as plt
 
 
@@ -293,10 +293,10 @@ def empirical(X):
 
 
 def graph_lasso(X, num_folds):
-    """Estimate inverse covariance via scikit-learn GraphLassoCV class.
+    """Estimate inverse covariance via scikit-learn GraphicalLassoCV class.
     """
     print("GraphLasso (sklearn)")
-    model = GraphLassoCV(cv=num_folds)
+    model = GraphicalLassoCV(cv=num_folds)
     model.fit(X)
     print("   lam_: {}".format(model.alpha_))
     return model.covariance_, model.precision_, model.alpha_
@@ -372,12 +372,12 @@ if __name__ == "__main__":
     print("   frobenius error: {}".format(error))
     print("")
 
-    # sklearn GraphLassoCV
+    # sklearn GraphicalLassoCV
     start_time = time.time()
     cov, prec, lam = graph_lasso(X, cv_folds)
     end_time = time.time()
     ctime = end_time - start_time
-    name = "GraphLassoCV (sklearn)"
+    name = "GraphicalLassoCV (sklearn)"
     plot_covs.append((name, cov))
     plot_precs.append((name, prec, lam))
     error = np.linalg.norm(true_cov - cov, ord="fro")

--- a/inverse_covariance/adaptive_graph_lasso.py
+++ b/inverse_covariance/adaptive_graph_lasso.py
@@ -95,7 +95,7 @@ class AdaptiveGraphicalLasso(BaseEstimator):
         X = as_float_array(X, copy=False, force_all_finite=False)
 
         n_samples_, n_features_ = X.shape
-
+        
         # perform first estimate
         estimator.fit(X)
 
@@ -139,6 +139,7 @@ class AdaptiveGraphicalLasso(BaseEstimator):
             )
 
         self.is_fitted_ = True
+        self.n_features_in_ = X.shape[1]
         return self
 
 

--- a/inverse_covariance/inverse_covariance.py
+++ b/inverse_covariance/inverse_covariance.py
@@ -161,6 +161,11 @@ class InverseCovarianceEstimator(BaseEstimator):
 
         super(InverseCovarianceEstimator, self).__init__()
 
+    def fit(self, X, y=None, **fit_params):
+        # To satisfy sklearn 
+        if len(y) == 1:
+            raise ValueError("Cannot fit with just 1 sample.")
+
     def init_coefs(self, X):
         """Computes ...
 

--- a/inverse_covariance/model_average.py
+++ b/inverse_covariance/model_average.py
@@ -319,7 +319,7 @@ class ModelAverage(BaseEstimator):
         self.n_jobs = n_jobs
         self.sc = sc
         self.seed = seed
-        self.prng = np.random.RandomState(seed)
+        
 
     def fit(self, X, y=None):
         """Learn a model averaged proportion matrix for X.
@@ -330,7 +330,10 @@ class ModelAverage(BaseEstimator):
         """
         # default to QuicGraphicalLasso
         estimator = self.estimator or QuicGraphicalLasso()
-
+        # To satisfy sklearn 
+        if y is not None and len(y) == 1:
+            raise ValueError("Cannot fit with just 1 sample.")
+        self._prng = np.random.RandomState(self.seed)
         if self.penalization != "subsampling" and not hasattr(
             estimator, self.penalty_name
         ):
@@ -370,7 +373,7 @@ class ModelAverage(BaseEstimator):
 
         if self.sc is None:
             results = _cpu_map(
-                partial(fit_fun, X=X, prng=self.prng),
+                partial(fit_fun, X=X, prng=self._prng),
                 indexed_param_grid,
                 n_jobs=self.n_jobs,
             )
@@ -410,7 +413,7 @@ class ModelAverage(BaseEstimator):
         self.lam_ /= self.n_trials
         if self.normalize:
             self.proportion_ /= self.n_trials
-
+        self.n_features_in_ = X.shape[1]
         return self
 
     @property

--- a/inverse_covariance/plot_util.py
+++ b/inverse_covariance/plot_util.py
@@ -1,7 +1,7 @@
 """Various utilities for Gaussian graphical models."""
 import sys
 import numpy as np
-from sklearn.utils.testing import assert_array_equal
+from sklearn.utils._testing import assert_array_equal
 from matplotlib import pyplot as plt
 import seaborn  # NOQA
 

--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -318,6 +318,11 @@ class QuicGraphicalLasso(InverseCovarianceEstimator):
         -------
         self
         """
+
+        # To satisfy sklearn 
+        if y is not None and len(y) == 1:
+            raise ValueError("Cannot fit with just 1 sample.")
+    
         # quic-specific outputs
         self.opt_ = None
         self.cputime_ = None
@@ -356,6 +361,7 @@ class QuicGraphicalLasso(InverseCovarianceEstimator):
             raise NotImplementedError("Only method='quic' has been implemented.")
 
         self.is_fitted_ = True
+        self.n_features_in_ = X.shape[1]
         return self
 
     def lam_at_index(self, lidx):
@@ -600,6 +606,11 @@ class QuicGraphicalLassoCV(InverseCovarianceEstimator):
         X : ndarray, shape (n_samples, n_features)
             Data from which to compute the covariance estimate
         """
+
+        # To satisfy sklearn 
+        if y is not None and len(y) == 1:
+            raise ValueError("Cannot fit with just 1 sample.")
+
         # quic-specific outputs
         self.opt_ = None
         self.cputime_ = None
@@ -795,6 +806,7 @@ class QuicGraphicalLassoCV(InverseCovarianceEstimator):
             raise NotImplementedError("Only method='quic' has been implemented.")
 
         self.is_fitted_ = True
+        self.n_features_in_ = X.shape[1]
         return self
 
 
@@ -930,6 +942,11 @@ class QuicGraphicalLassoEBIC(InverseCovarianceEstimator):
         -------
         self
         """
+
+        # To satisfy sklearn 
+        if y is not None and len(y) == 1:
+            raise ValueError("Cannot fit with just 1 sample.")
+
         # quic-specific outputs
         self.opt_ = None
         self.cputime_ = None
@@ -985,6 +1002,7 @@ class QuicGraphicalLassoEBIC(InverseCovarianceEstimator):
         self.covariance_ = self.covariance_[best_lam_idx]
 
         self.is_fitted_ = True
+        self.n_features_in_ = X.shape[1]
         return self
 
 

--- a/inverse_covariance/tests/common_test.py
+++ b/inverse_covariance/tests/common_test.py
@@ -9,20 +9,20 @@ from inverse_covariance import (
 
 
 def test_quic_graphical_lasso():
-    return check_estimator(QuicGraphicalLasso)
+    return check_estimator(QuicGraphicalLasso())
 
 
 def test_quic_graphical_lasso_cv():
-    return check_estimator(QuicGraphicalLassoCV)
+    return check_estimator(QuicGraphicalLassoCV())
 
 
 def test_quic_graphical_lasso_ebic():
-    return check_estimator(QuicGraphicalLassoEBIC)
+    return check_estimator(QuicGraphicalLassoEBIC())
 
 
 def test_adaptive_graphical_lasso():
-    return check_estimator(AdaptiveGraphicalLasso)
+    return check_estimator(AdaptiveGraphicalLasso())
 
 
 def test_model_average():
-    return check_estimator(ModelAverage)
+    return check_estimator(ModelAverage())

--- a/inverse_covariance/tests/model_average_test.py
+++ b/inverse_covariance/tests/model_average_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from sklearn.covariance import GraphLassoCV
+from sklearn.covariance import GraphicalLassoCV
 
 from inverse_covariance import QuicGraphicalLassoCV, QuicGraphicalLasso, ModelAverage
 from inverse_covariance.profiling import ClusterGraph
@@ -42,7 +42,7 @@ class TestModelAverage(object):
             ),
             (
                 {
-                    "estimator": GraphLassoCV(cv=2),
+                    "estimator": GraphicalLassoCV(cv=2),
                     "n_trials": 2,
                     "normalize": True,
                     "subsample": 0.9,

--- a/inverse_covariance/tests/quic_graph_lasso_test.py
+++ b/inverse_covariance/tests/quic_graph_lasso_test.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_allclose
+from sklearn.utils._testing import assert_raises
+from sklearn.utils._testing import assert_allclose
 from sklearn import datasets
 
 from inverse_covariance import (

--- a/inverse_covariance/tests/rank_correlation_test.py
+++ b/inverse_covariance/tests/rank_correlation_test.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils._testing import assert_array_almost_equal
 
 from inverse_covariance.rank_correlation import (
     _compute_ranks,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Cython>=0.24
 nilearn>=0.2.4
 numpy>=1.12.1
-scikit-learn>=0.19
+scikit-learn>=1.1.13
 scipy>=0.23.0
 pytest>=2.9.2
 seaborn>=0.7.1


### PR DESCRIPTION
Thanks for a great repo. I see that it is not being actively developed anymore. Not sure if this is of interest but I figured I'd offer thsi compatibiity fix. Feel free to modify.

Bump scikit-learn to `scikit-learn==1.1.3`

Please test on local environment. 

I also see that there is no py3.7-3.10 comp. Any plans to add this? Should be fairly straight forward to just modify the .travis file if it still builds on merges.