### PR TITLE
Fix security vulnerabilities + core correctness bugs (eBIC, ModelAverage)

### DIFF
--- a/examples/estimator_suite.py
+++ b/examples/estimator_suite.py
@@ -32,9 +32,10 @@ from inverse_covariance import (
 plt.ion()
 
 
-def r_input(val):
+def r_input(val=""):
+    # Just pauses execution; do not eval() user input (code injection risk).
     if sys.version_info[0] >= 3:
-        return eval(input(val))
+        return input(val)
 
     return raw_input(val)
 

--- a/examples/plot_functional_brain_networks.py
+++ b/examples/plot_functional_brain_networks.py
@@ -110,4 +110,4 @@ plotting.plot_connectome(
 )
 plotting.show()
 
-eval(input("Press any key to exit.."))
+input("Press any key to exit..")

--- a/examples/profiling_example.py
+++ b/examples/profiling_example.py
@@ -26,9 +26,10 @@ from inverse_covariance.profiling import (
 plt.ion()
 
 
-def r_input(val):
+def r_input(val=""):
+    # Just pauses execution; do not eval() user input (code injection risk).
     if sys.version_info[0] >= 3:
-        return eval(input(val))
+        return input(val)
 
     return raw_input(val)
 

--- a/inverse_covariance/_compat.py
+++ b/inverse_covariance/_compat.py
@@ -1,0 +1,17 @@
+"""Compatibility helpers for the supported range of scikit-learn versions."""
+from sklearn.utils import as_float_array as _sklearn_as_float_array
+
+
+def as_float_array(X, copy=False, ensure_all_finite=False):
+    """``sklearn.utils.as_float_array`` with a version-stable finiteness kwarg.
+
+    scikit-learn renamed the ``force_all_finite`` argument to
+    ``ensure_all_finite`` in 1.6 and removed the old spelling in 1.9.  Prefer
+    the new name and fall back to the old one so skggm works across the
+    supported range (>=1.5) without emitting deprecation warnings on newer
+    releases or breaking on older ones.
+    """
+    try:
+        return _sklearn_as_float_array(X, copy=copy, ensure_all_finite=ensure_all_finite)
+    except TypeError:
+        return _sklearn_as_float_array(X, copy=copy, force_all_finite=ensure_all_finite)

--- a/inverse_covariance/adaptive_graph_lasso.py
+++ b/inverse_covariance/adaptive_graph_lasso.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
 import numpy as np
-from sklearn.utils import check_array, as_float_array, deprecated
+from sklearn.utils import check_array, deprecated
 from sklearn.base import BaseEstimator
+from ._compat import as_float_array
 
 from . import QuicGraphicalLasso, QuicGraphicalLassoCV, InverseCovarianceEstimator
 
@@ -92,7 +93,7 @@ class AdaptiveGraphicalLasso(BaseEstimator):
         self.estimator_ = None
 
         X = check_array(X, ensure_min_features=2, estimator=self)
-        X = as_float_array(X, copy=False, force_all_finite=False)
+        X = as_float_array(X, copy=False, ensure_all_finite=False)
 
         n_samples_, n_features_ = X.shape
         

--- a/inverse_covariance/metrics.py
+++ b/inverse_covariance/metrics.py
@@ -114,7 +114,7 @@ def ebic(covariance, precision, n_samples, n_features, gamma=0):
     ebic score (float).  Caller should minimized this score.
     """
     l_theta = -np.sum(covariance * precision) + fast_logdet(precision)
-    l_theta *= n_features / 2.
+    l_theta *= n_samples / 2.
 
     # is something goes wrong with fast_logdet, return large value
     if np.isinf(l_theta) or np.isnan(l_theta):

--- a/inverse_covariance/model_average.py
+++ b/inverse_covariance/model_average.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 import numpy as np
 from sklearn.base import BaseEstimator, clone
-from sklearn.utils import check_array, as_float_array
+from sklearn.utils import check_array
+from ._compat import as_float_array
 from joblib import Parallel, delayed
 from functools import partial
 
@@ -353,7 +354,7 @@ class ModelAverage(BaseEstimator):
         self.subsets_ = []
 
         X = check_array(X, ensure_min_features=2, estimator=self)
-        X = as_float_array(X, copy=False, force_all_finite=False)
+        X = as_float_array(X, copy=False, ensure_all_finite=False)
 
         n_samples_, n_features_ = X.shape
         _, self.lam_scale_ = _init_coefs(X, method=self.init_method)

--- a/inverse_covariance/model_average.py
+++ b/inverse_covariance/model_average.py
@@ -403,7 +403,9 @@ class ModelAverage(BaseEstimator):
 
             # currently, dont estimate self.lam_ if penalty_name is different
             if self.penalty_name == "lam":
-                self.lam_ += np.mean(new_estimator.lam_.flat)
+                # new_estimator.lam_ may be a scalar (float) or an ndarray;
+                # np.mean handles both (a bare float has no ``.flat``).
+                self.lam_ += np.mean(new_estimator.lam_)
 
         # estimate support locations
         threshold = self.support_thresh * self.n_trials

--- a/inverse_covariance/plot_util.py
+++ b/inverse_covariance/plot_util.py
@@ -8,9 +8,16 @@ import seaborn  # NOQA
 plt.ion()
 
 
-def r_input(val):
+def r_input(val=""):
+    """Prompt for and return a line of input.
+
+    Used only to pause execution (e.g. "Press any key to continue"); the
+    return value is discarded by callers.  Note: do not wrap ``input`` in
+    ``eval`` -- doing so evaluates whatever the user types as Python code,
+    which is an arbitrary code execution risk.
+    """
     if sys.version_info[0] >= 3:
-        return eval(input(val))
+        return input(val)
 
     return raw_input(val)  # NOQA
 

--- a/inverse_covariance/quic_graph_lasso.py
+++ b/inverse_covariance/quic_graph_lasso.py
@@ -7,7 +7,8 @@ import numpy as np
 from functools import partial
 
 from sklearn.covariance import EmpiricalCovariance
-from sklearn.utils import check_array, as_float_array, deprecated
+from sklearn.utils import check_array, deprecated
+from ._compat import as_float_array
 from numpy.testing import assert_array_almost_equal
 from joblib import Parallel, delayed
 from sklearn.model_selection import cross_val_score, RepeatedKFold
@@ -65,7 +66,7 @@ def quic(
         _lam[np.diag_indices(Sn)] = 0.  # make sure diagonal is zero
     else:
         assert lam.shape == S.shape, "lam, S shape mismatch."
-        _lam = as_float_array(lam, copy=False, force_all_finite=False)
+        _lam = as_float_array(lam, copy=False, ensure_all_finite=False)
 
     # Defaults.
     optSize = 1
@@ -82,8 +83,8 @@ def quic(
     assert Sigma0 is not None, "Theta0 and Sigma0 must both be None or both specified."
     assert Theta0.shape == S.shape, "Theta0, S shape mismatch."
     assert Sigma0.shape == S.shape, "Theta0, Sigma0 shape mismatch."
-    Theta0 = as_float_array(Theta0, copy=False, force_all_finite=False)
-    Sigma0 = as_float_array(Sigma0, copy=False, force_all_finite=False)
+    Theta0 = as_float_array(Theta0, copy=False, ensure_all_finite=False)
+    Sigma0 = as_float_array(Sigma0, copy=False, ensure_all_finite=False)
 
     if mode == "path":
         assert path is not None, "Please specify the path scaling values."
@@ -336,7 +337,7 @@ class QuicGraphicalLasso(InverseCovarianceEstimator):
 
         self.path_ = _validate_path(self.path)
         X = check_array(X, ensure_min_features=2, estimator=self)
-        X = as_float_array(X, copy=False, force_all_finite=False)
+        X = as_float_array(X, copy=False, ensure_all_finite=False)
         self.init_coefs(X)
         if self.method == "quic":
             (
@@ -624,7 +625,7 @@ class QuicGraphicalLassoCV(InverseCovarianceEstimator):
 
         # initialize
         X = check_array(X, ensure_min_features=2, estimator=self)
-        X = as_float_array(X, copy=False, force_all_finite=False)
+        X = as_float_array(X, copy=False, ensure_all_finite=False)
 
         if self.cv is None:
             cv = (3, 10)
@@ -961,7 +962,7 @@ class QuicGraphicalLassoEBIC(InverseCovarianceEstimator):
         self.is_fitted_ = False
 
         X = check_array(X, ensure_min_features=2, estimator=self)
-        X = as_float_array(X, copy=False, force_all_finite=False)
+        X = as_float_array(X, copy=False, ensure_all_finite=False)
         self.init_coefs(X)
 
         # either use passed in path, or make our own path

--- a/inverse_covariance/tests/model_average_test.py
+++ b/inverse_covariance/tests/model_average_test.py
@@ -51,6 +51,19 @@ class TestModelAverage(object):
                 }
             ),
             (
+                # Regression test for #103: in subsampling mode with the
+                # default scalar penalty, new_estimator.lam_ is a float, so
+                # the reduce step must not assume an ndarray (no `.flat`).
+                {
+                    "estimator": QuicGraphicalLasso(lam=0.1),
+                    "n_trials": 2,
+                    "normalize": True,
+                    "subsample": 0.6,
+                    "penalization": "subsampling",
+                    "penalty_name": "lam",
+                }
+            ),
+            (
                 {
                     "estimator": QuicGraphicalLasso(),
                     "n_trials": 10,

--- a/inverse_covariance/tests/quic_graph_lasso_test.py
+++ b/inverse_covariance/tests/quic_graph_lasso_test.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 
-from sklearn.utils._testing import assert_raises
-from sklearn.utils._testing import assert_allclose
+from numpy.testing import assert_allclose
 from sklearn import datasets
 
 from inverse_covariance import (
@@ -274,11 +273,11 @@ class TestQuicGraphicalLasso(object):
     @pytest.mark.parametrize(
         "params_in, expected",
         [
-            ({}, [3.1622776601683795, 3.1622776601683795, 0.91116275611548958]),
-            ({"lam": 0.5 * np.ones((10, 10))}, [4.797, 2.1849]),
+            ({}, [4.5357, 14.2735, 0.035111917342151314]),
+            ({"lam": 0.5 * np.ones((10, 10))}, [4.6429, 14.7006]),
             (
                 {"lam": 0.5 * np.ones((10, 10)), "init_method": custom_init},
-                [0.0106, 35056.88460],
+                [0.0106, 35117.96334856725],
             ),  # NOQA
         ],
     )
@@ -305,4 +304,5 @@ class TestQuicGraphicalLasso(object):
         """
         X = datasets.load_diabetes().data
         ic = QuicGraphicalLasso(method="unknownmethod")
-        assert_raises(NotImplementedError, ic.fit, X)
+        with pytest.raises(NotImplementedError):
+            ic.fit(X)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Cython>=0.24
 nilearn>=0.2.4
 numpy>=1.12.1, <2.0
-scikit-learn>=1.1.13
+scikit-learn>=1.5.0
 scipy>=0.23.0
 pytest>=2.9.2
 seaborn>=0.7.1
 nose>=1.3.6
 tabulate==0.7.5
-joblib>=0.16.0
+joblib>=1.2.0


### PR DESCRIPTION
## Summary

This PR addresses the security alerts first, then implements the highest-value, lowest-risk maintenance fixes found while triaging the open issues. Everything is validated against a freshly built `pyquic` extension with the full test suite (**45 passing** on scikit-learn 1.5.2 / numpy 1.26.4).

## 1. Security fixes

### Dependency vulnerabilities (the Dependabot alerts: 1 high + 1 moderate)
Confirmed via `pip-audit` against the manifest's lower bounds:

| Severity | Package | Advisory | Old floor | New floor |
|----------|---------|----------|-----------|-----------|
| **High** | `joblib` | PYSEC-2022-288 / CVE-2022-21797 — arbitrary code execution via `pre_dispatch` `eval()` in `Parallel` | `>=0.16.0` | **`>=1.2.0`** |
| **Moderate** | `scikit-learn` | PYSEC-2024-110 / CVE-2024-5206 — sensitive data leakage in `TfidfVectorizer` | `>=1.1.13` | **`>=1.5.0`** |

`pip-audit` reports **no known vulnerabilities** for the new floors.

Raising the scikit-learn floor would have broken `fit()` on its own: sklearn 1.6 renamed `as_float_array`'s `force_all_finite` argument to `ensure_all_finite` and **removed** the old name in 1.9 (`TypeError: as_float_array() got an unexpected keyword argument 'force_all_finite'`). Added `inverse_covariance/_compat.py::as_float_array`, a thin wrapper that prefers the new kwarg and falls back to the old one, and routed the three modules through it. Validated against scikit-learn **1.4.2, 1.5.2, and 1.6.1** (the wrapper's primary path emits no deprecation warning on >=1.6).

### Code-level: arbitrary code execution via `eval(input())`
`inverse_covariance/plot_util.py::r_input` wrapped `input()` in `eval()`. The return value is only used to pause execution ("Press any key to continue"), so `eval` served no purpose while letting any Python typed at the prompt run (CWE-94/95). Fixed in the shipped library and in the example scripts (`estimator_suite.py`, `profiling_example.py`, `plot_functional_brain_networks.py`).

## 2. Correctness bugs (top-priority open issues)

- **#138 — eBIC scaling.** `metrics.ebic` scaled the Gaussian log-likelihood by `n_features/2` instead of `n_samples/2`. Per Foygel & Drton (2010) the maximized log-likelihood is `(n_samples/2)·[logdet(Θ) − tr(SΘ)]`, so model selection was incorrectly driven by dimensionality rather than sample size. Fixed and the eBIC integration-test expectations regenerated.
- **#103 — ModelAverage scalar penalty.** The reduce step did `np.mean(new_estimator.lam_.flat)`, which raised `AttributeError` when `lam_` is a bare float (e.g. subsampling mode with the default scalar penalty). Switched to `np.mean(new_estimator.lam_)`, which handles scalars and arrays, and added a regression test.
- **#126 — verified already fixed** on `develop` (init no longer sets `prng`; `fit` uses `self._prng`).

## 3. Test-suite maintenance

- Replaced the removed `sklearn.utils._testing.assert_raises` with `pytest.raises` so the suite collects on modern scikit-learn.

## Issue triage / recommended follow-ups

While here I reviewed the 31 open issues. Suggested priority order for the next round:

1. **scikit-learn 1.6+ `__sklearn_tags__` migration** — on sklearn ≥1.6 the *real* estimators work, but the generic `check_estimator` conformance tests (`common_test.py`) fail because of the 1.6 estimator-tags API overhaul. This is the main blocker to fully supporting current sklearn and fits under the existing "sklearn cleanup" effort (#130/#131).
2. **#91 — numpy/`slogdet` NaN handling** in `metrics.py`/`ebic_select` (same area as #138; guards against zero-size reductions).
3. **#56 — eBIC lambda-grid robustness** (the eBIC integration values are version-sensitive; worth replacing hardcoded characterization values with validity-based assertions).
4. **#108 — distribute wheels** (recurring user pain, e.g. #123, #132).

Note: Dependabot PR **#137** (bump `black` for CVE-2024-21503) is a separate dev-tooling security update worth merging too.

## Test plan
- Built `pyquic` against lapack; ran `pytest inverse_covariance/tests/` → **45 passed** on sklearn 1.5.2.
- `pip-audit` clean on `joblib==1.2.0` + `scikit-learn==1.5.0`.
- Cross-checked the compat shim on sklearn 1.4.2 / 1.5.2 / 1.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019LJqdWmM6gbHG8XUVsyssV)_